### PR TITLE
Added a feature that allows multiple fields to be updated in a single request

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,10 @@ their appropriate sections. Import the API class(es) you want to leverage and th
     >>> ticket_notes = ticket_notes_api.TicketNotesAPI(url=URL, auth=AUTH, ticket_id=TICKET_ID)
     >>> note = ticket_note.TicketNote({"text":"testing ticket note update.. ", "detailDescriptionFlag": True})
     >>> ticket_notes.create_ticket_note(note)
+
+### For example to update multiple fields on a ticket:
+
+    >>> from connectpyse.service import tickets_api 
+    >>> api = tickets_api.TicketsAPI(url=URL, auth=AUTH)
+    >>> mychanges = {"summary": "update multiple keys", "budgetHours": .50}
+    >>> ticket = api.update_ticket_multiple_keys(ticketId, mychanges)

--- a/company/companies_api.py
+++ b/company/companies_api.py
@@ -31,6 +31,9 @@ class CompaniesAPI(CWController):
     def update_company(self, company_id, key, value):
         return super()._update(company_id, key, value)
 
+    def update_company_multiple_keys(self, company_id, changes_dict):
+        return super()._update_multiple_keys(company_id, changes_dict)
+
     def merge_company(self, a_company, target_company_id):
         # return super()._merge(a_company, target_company_id)
         pass

--- a/company/company_management_summary_reports_api.py
+++ b/company/company_management_summary_reports_api.py
@@ -30,3 +30,6 @@ class CompanyManagementSummaryReportsAPI(CWController):
 
     def update_managementSummaryReport(self, managementSummaryReport_id, key, value):
         return super()._update(managementSummaryReport_id, key, value)
+
+    def update_managementSummaryReport_multiple_keys(self, managementSummaryReport_id, changes_dict):
+        return super()._update_multiple_keys(managementSummaryReport_id, changes_dict)

--- a/company/company_statuses_api.py
+++ b/company/company_statuses_api.py
@@ -31,6 +31,9 @@ class CompanyStatusAPI(CWController):
     def update_company_status(self, company_id, key, value):
         return super()._update(company_id, key, value)
 
+    def update_company_status_multiple_keys(self, company_id, changes_dict):
+        return super()._update_multiple_keys(company_id, changes_dict)
+
     def merge_company_status(self, a_company_status, target_company_status_id):
         # return super()._merge(a_company_status, target_company_status_id)
         pass

--- a/company/company_types_api.py
+++ b/company/company_types_api.py
@@ -31,6 +31,9 @@ class CompanyTypeAPI(CWController):
     def update_company_type(self, company_type_id, key, value):
         return super()._update(company_type_id, key, value)
 
+    def update_company_type_multiple_keys(self, company_type_id, changes_dict):
+        return super()._update_multiple_keys(company_type_id, changes_dict)
+
     def merge_company_type(self, a_company_type, target_company_type_id):
         # return super()._merge(a_company_type, target_company_type_id)
         pass

--- a/company/configurations_api.py
+++ b/company/configurations_api.py
@@ -31,3 +31,6 @@ class ConfigurationsAPI(CWController):
     def update_configuration(self, configuration_id, key, value):
         return super()._update(configuration_id, key, value)
 
+    def update_configuration_multiple_keys(self, configuration_id, changes_dict):
+        return super()._update_multiple_keys(configuration_id, changes_dict)
+

--- a/company/contact_communications_api.py
+++ b/company/contact_communications_api.py
@@ -30,3 +30,6 @@ class ContactCommunicationsAPI(CWController):
 
     def update_contact_communication(self, item_id, key, value):
         return super()._update(item_id, key, value)
+
+    def update_contact_communication_multiple_keys(self, item_id, changes_dict):
+        return super()._update_multiple_keys(item_id, changes_dict)

--- a/company/contacts_api.py
+++ b/company/contacts_api.py
@@ -31,6 +31,9 @@ class ContactsAPI(CWController):
     def update_contact(self, contact_id, key, value):
         return super()._update(contact_id, key, value)
 
+    def update_contact_multiple_keys(self, contact_id, changes_dict):
+        return super()._update_multiple_keys(contact_id, changes_dict)
+
     def merge_contact(self, a_contact, target_contact_id):
         # return super()._merge(a_contact, target_contact_id)
         pass

--- a/cw_controller.py
+++ b/cw_controller.py
@@ -83,6 +83,20 @@ class CWController(Client):
                                                                    user_headers=self.basic_auth))
         return an_instance
 
+    def _update_multiple_keys(self, item_id, keys_dict):
+        # build PatchOperation dict
+        patch_operation = []
+        for key, value in keys_dict.items():
+            patch_dict = {'op': 'replace', 'path': key, 'value': value}
+            patch_operation.append(patch_dict)
+
+        # call Patch method on API
+        an_instance = self._class(getattr(self, self.module).patch(the_id=item_id, user_data=patch_operation,
+                                                                   user_headers=self.basic_auth))
+        return an_instance
+
+
+
     def _merge(self, a_object, target_id):  # TODO: test
         # try:
         #     clean_dict = {k: v for k, v in a_object.__dict__.items() if v}

--- a/finance/agreement_additions_api.py
+++ b/finance/agreement_additions_api.py
@@ -31,3 +31,6 @@ class AgreementAdditionsAPI(CWController):
 
     def update_agreement_addition(self, agreement_addition_id, key, value):
         return super()._update(agreement_addition_id, key, value)
+
+    def update_agreement_addition_multiple_keys(self, agreement_addition_id, changes_dict):
+        return super()._update_multiple_keys(agreement_addition_id, changes_dict)

--- a/finance/agreements_api.py
+++ b/finance/agreements_api.py
@@ -32,6 +32,9 @@ class AgreementsAPI(CWController):
     def update_agreement(self, agreement_id, key, value):
         return super()._update(agreement_id, key, value)
 
+    def update_agreement_multiple_keys(self, agreement_id, changes_dict):
+        return super()._update_multiple_keys(agreement_id, changes_dict)
+
     def merge_agreement(self, agreement_id):
         pass
 

--- a/procurement/catalog_item_api.py
+++ b/procurement/catalog_item_api.py
@@ -28,5 +28,8 @@ class CatalogItemAPI(CWController):
     def replace_catalog_item(self, catalog_item_id):
         pass
 
+    def update_catalog_multiple_keys(self, catalog_item_id, changes_dict):
+        return super()._update_multiple_keys(catalog_item_id, changes_dict)
+
     def update_catalog_item(self, catalog_item_id, key, value):
         return super()._update(catalog_item_id, key, value)

--- a/procurement/manufacturer_api.py
+++ b/procurement/manufacturer_api.py
@@ -30,3 +30,6 @@ class ManufacturerAPI(CWController):
 
     def update_manufacturer(self, manufacturer_id, key, value):
         return super()._update(manufacturer_id, key, value)
+
+    def update_manufacturer_multiple_keys(self, manufacturer_id, changes_dict):
+        return super()._update_multiple_keys(manufacturer_id, changes_dict)

--- a/procurement/product_item_api.py
+++ b/procurement/product_item_api.py
@@ -30,3 +30,6 @@ class ProductItemAPI(CWController):
 
     def update_product_item(self, product_item_id, key, value):
         return super()._update(product_item_id, key, value)
+
+    def update_product_item_multiple_keys(self, product_item_id, changes_dict):
+        return super()._update_multiple_keys(product_item_id, changes_dict)

--- a/procurement/purchase_order_api.py
+++ b/procurement/purchase_order_api.py
@@ -30,3 +30,6 @@ class PurchaseOrderAPI(CWController):
 
     def update_purchase_order(self, purchase_order_id, key, value):
         return super()._update(purchase_order_id, key, value)
+
+    def update_purchase_order_multiple_keys(self, purchase_order_id, changes_dict):
+        return super()._update_multiple_keys(purchase_order_id, changes_dict)

--- a/procurement/purchase_order_line_item_api.py
+++ b/procurement/purchase_order_line_item_api.py
@@ -30,3 +30,6 @@ class PurchaseOrderLineItemAPI(CWController):
 
     def update_purchase_order_line_item(self, purchase_order_line_item_id, key, value):
         return super()._update(purchase_order_line_item_id, key, value)
+
+    def update_purchase_order_line_item_multiple_keys(self, purchase_order_line_item_id, changes_dict):
+        return super()._update_multiple_keys(purchase_order_line_item_id, changes_dict)

--- a/procurement/purchase_order_status_api.py
+++ b/procurement/purchase_order_status_api.py
@@ -30,3 +30,6 @@ class PurchaseOrderStatusAPI(CWController):
 
     def update_purchase_order_status(self, purchase_order_status_id, key, value):
         return super()._update(purchase_order_status_id, key, value)
+
+    def update_purchase_order_multiple_keys(self, purchase_order_status_id, changes_dict):
+        return super()._update_multiple_keys(purchase_order_status_id, changes_dict)

--- a/procurement/shipment_methods_api.py
+++ b/procurement/shipment_methods_api.py
@@ -30,3 +30,6 @@ class ShipmentMethodsAPI(CWController):
 
     def update_shipment_method(self, shipment_method_id, key, value):
         return super()._update(shipment_method_id, key, value)
+
+    def update_shipment_method_multiple_keys(self, shipment_method_id, changes_dict):
+        return super()._update_multiple_keys(shipment_method_id, changes_dict)

--- a/project/projects_api.py
+++ b/project/projects_api.py
@@ -31,6 +31,9 @@ class ProjectsAPI(CWController):
     def update_project(self, project_id, key, value):
         return super()._update(project_id, key, value)
 
+    def update_project_multiple_keys(self, project_id, changes_dict):
+        return super()._update_multiple_keys(project_id, changes_dict)
+
     def merge_project(self, a_project, target_project_id):
         # return super()._merge(a_project, target_project_id)
         pass

--- a/sales/activity_api.py
+++ b/sales/activity_api.py
@@ -31,6 +31,9 @@ class ActivityAPI(CWController):
     def update_activity(self, type_id, key, value):
         return super()._update(type_id, key, value)
 
+    def update_activity_multiple_keys(self, type_id, changes_dict):
+        return super()._update_multiple_keys(type_id, changes_dict)
+
     def merge_activity(self, a_type, target_type_id):
         # return super()._merge(a_type, target_type_id)
         pass

--- a/sales/opportunity_api.py
+++ b/sales/opportunity_api.py
@@ -31,6 +31,9 @@ class OpportunityAPI(CWController):
     def update_opportunity(self, type_id, key, value):
         return super()._update(type_id, key, value)
 
+    def update_opportunity_multiple_keys(self, type_id, changes_dict):
+        return super()._update_multiple_keys(type_id, changes_dict)
+
     def merge_opportunity(self, a_type, target_type_id):
         # return super()._merge(a_type, target_type_id)
         pass

--- a/sales/opportunity_forecast_api.py
+++ b/sales/opportunity_forecast_api.py
@@ -30,3 +30,6 @@ class OpportunityForecastAPI(CWController):
 
     def update_opportunity_forecast(self, opportunity_forecast_id, key, value):
         return super()._update(opportunity_forecast_id, key, value)
+
+    def update_opportunity_forecast_multiple_keys(self, opportunity_forecast_id, changes_dict):
+        return super()._update_multiple_keys(opportunity_forecast_id, changes_dict)

--- a/sales/order_api.py
+++ b/sales/order_api.py
@@ -30,3 +30,6 @@ class OrderAPI(CWController):
 
     def update_order(self, order_id, key, value):
         return super()._update(order_id, key, value)
+
+    def update_order_multiple_keys(self, order_id, changes_dict):
+        return super()._update_multiple_keys(order_id, changes_dict)

--- a/schedule/schedule_entries_api.py
+++ b/schedule/schedule_entries_api.py
@@ -31,6 +31,9 @@ class ScheduleEntriesAPI(CWController):
     def update_schedule_entry(self, entry_id, key, value):
         return super()._update(entry_id, key, value)
 
+    def update_schedule_entry_multiple_keys(self, entry_id, changes_dict):
+        return super()._update_multiple_keys(entry_id, changes_dict)
+
     def merge_schedule_entry(self, a_entry, target_entry_id):
         # return super()._merge(a_schedule_entry, target_schedule_entry_id)
         pass

--- a/schedule/schedule_reminder_times_api.py
+++ b/schedule/schedule_reminder_times_api.py
@@ -31,6 +31,9 @@ class ScheduleReminderTimesAPI(CWController):
     def update_schedule_reminder_time(self, reminder_time_id, key, value):
         return super()._update(reminder_time_id, key, value)
 
+    def update_schedule_reminder_time_multiple_keys(self, reminder_time_id, changes_dict):
+        return super()._update_multiple_keys(reminder_time_id, changes_dict)
+
     def merge_schedule_reminder_time(self, a_reminder_time, target_reminder_time_id):
         # return super()._merge(a_schedule_reminder_time, target_schedule_reminder_time_id)
         pass

--- a/schedule/schedule_statuses_api.py
+++ b/schedule/schedule_statuses_api.py
@@ -31,6 +31,9 @@ class ScheduleStatusesAPI(CWController):
     def update_schedule_status(self, status_id, key, value):
         return super()._update(status_id, key, value)
 
+    def update_schedule_status_multiple_keys(self, status_id, changes_dict):
+        return super()._update_multiple_keys(status_id, changes_dict)
+
     def merge_schedule_status(self, a_status, target_status_id):
         # return super()._merge(a_schedule_status, target_schedule_status_id)
         pass

--- a/schedule/schedule_types_api.py
+++ b/schedule/schedule_types_api.py
@@ -31,6 +31,9 @@ class ScheduleTypesAPI(CWController):
     def update_schedule_type(self, type_id, key, value):
         return super()._update(type_id, key, value)
 
+    def update_schedule_type_multiple_keys(self, type_id, changes_dict):
+        return super()._update_multiple_keys(type_id, changes_dict)
+
     def merge_schedule_type(self, a_type, target_type_id):
         # return super()._merge(a_schedule_type, target_schedule_type_id)
         pass

--- a/service/boards_api.py
+++ b/service/boards_api.py
@@ -31,6 +31,9 @@ class BoardsAPI(CWController):
     def update_board(self, entry_id, key, value):
         return super()._update(entry_id, key, value)
 
+    def update_board_multiple_keys(self, entry_id, changes_dict):
+        return super()._update_multiple_keys(entry_id, changes_dict)
+
     def merge_board(self, a_entry, target_entry_id):
         # return super()._merge(a_board, target_board_id)
         pass

--- a/service/ticket_notes_api.py
+++ b/service/ticket_notes_api.py
@@ -31,6 +31,9 @@ class TicketNotesAPI(CWController):
     def update_ticket_note(self, ticket_id, key, value):
         return super()._update(ticket_id, key, value)
 
+    def update_ticket_note_multiple_keys(self, ticket_id, changes_dict):
+        return super()._update_multiple_keys(ticket_id, changes_dict)
+
     def merge_ticket_note(self, a_ticket_note, target_ticket_note_id):
         # return super()._merge(a_ticket_note, target_ticket_note_id)
         pass

--- a/service/tickets_api.py
+++ b/service/tickets_api.py
@@ -28,6 +28,9 @@ class TicketsAPI(CWController):
     def replace_ticket(self, ticket_id):
         pass
 
+    def update_ticket_multiple_keys(self, ticket_id, changes_dict):
+        return super()._update_multiple_keys(ticket_id, changes_dict)
+
     def update_ticket(self, ticket_id, key, value):
         return super()._update(ticket_id, key, value)
 

--- a/system/callbacks_api.py
+++ b/system/callbacks_api.py
@@ -31,6 +31,9 @@ class CallbacksAPI(CWController):
     def update_callback(self, entry_id, key, value):
         return super()._update(entry_id, key, value)
 
+    def update_callback_multiple_keys(self, entry_id, changes_dict):
+        return super()._update_multiple_keys(entry_id, changes_dict)
+
     def merge_callback(self, a_entry, target_entry_id):
         # return super()._merge(a_callback, target_callback_id)
         pass

--- a/system/document_api.py
+++ b/system/document_api.py
@@ -56,6 +56,9 @@ class DocumentAPI(CWController):
     def update_document(self, type_id, key, value):
         pass
 
+    def update_document_multiple_keys(self, entry_id, changes_dict):
+        pass
+
     def merge_document(self, a_type, target_type_id):
         # return super()._merge(a_type, target_type_id)
         pass

--- a/system/document_api.py
+++ b/system/document_api.py
@@ -56,7 +56,7 @@ class DocumentAPI(CWController):
     def update_document(self, type_id, key, value):
         pass
 
-    def update_document_multiple_keys(self, entry_id, changes_dict):
+    def update_document_multiple_keys(self, type_id, changes_dict):
         pass
 
     def merge_document(self, a_type, target_type_id):

--- a/system/members_api.py
+++ b/system/members_api.py
@@ -31,6 +31,9 @@ class MembersAPI(CWController):
     def update_member(self, type_id, key, value):
         return super()._update(type_id, key, value)
 
+    def update_member_multiple_keys(self, type_id, changes_dict):
+        return super()._update_multiple_keys(type_id, changes_dict)
+
     def merge_member(self, a_type, target_type_id):
         # return super()._merge(a_type, target_type_id)
         pass

--- a/time/time_entries_api.py
+++ b/time/time_entries_api.py
@@ -30,3 +30,6 @@ class TimeEntriesAPI(CWController):
 
     def update_time_entry(self, time_entry_id, key, value):
         return super()._update(time_entry_id, key, value)
+
+    def update_time_entry_multiple_keys(self, time_entry_id, changes_dict):
+        return super()._update_multiple_keys(time_entry_id, changes_dict)


### PR DESCRIPTION
Currently the _update function in cw_controller takes in a single key and value and constructs a api request.  This requires one request per each field that requires an update. The new method added to the TicketApi allows for a dictionary of key updates to be provided and it will construct a multi-field update within a single request.

This will address concerns (eventually) from open issue #14.  I only modified the TicketApi within this update but will update the other endpoints after determining if this is an ideal update for the project.  Please provide feedback for required changes.