### PR TITLE
restapi delete method does not work

### DIFF
--- a/restapi.py
+++ b/restapi.py
@@ -181,15 +181,20 @@ class Endpoint(object):
         else:
             return self._formatreturn(resp)
 
-    def delete(self, level=None, user_params={}, user_headers={}):
+    def delete(self, the_id=None, level=None, user_params={}, user_headers={}):
+
+        if the_id:
+            url = self._url(self.endpoint, the_id)
+        else:
+            url = self._url(self.endpoint)
 
         resp = req.delete(
-            self._url(self.endpoint),
+            url,
             headers=self._headers(user_headers),
             params=self._params(user_params)
         )
 
-        if resp.status_code != 200:
+        if resp.status_code != 204:
             raise ApiError(
                 "DELETE",
                 self.endpoint,


### PR DESCRIPTION
Hey @markciecior,

I found an issue with using the delete method to delete resources. Let me know if you have any concerns with my suggested fix.

Thanks!

-----

When attempting to delete a resource by ID (for example `cw_callbacks_api.delete_callback_by_id`) an error is thrown

```
cw_callbacks_api.delete_callback_by_id(callback.id)

  File ".../connectpyse/system/callbacks_api.py", line 26, in delete_callback_by_id
    super()._delete_by_id(entry_id)
  File ".../connectpyse/cw_controller.py", line 67, in _delete_by_id
    return getattr(self, self.module).delete(the_id=item_id, user_headers=self.basic_auth)
TypeError: delete() got an unexpected keyword argument 'the_id'
```
https://github.com/markciecior/ConnectPyse/blob/1cd82ab94a9973cdf69c0d872bf45e3d0244d34a/cw_controller.py#L66-L67

calls `delete` with a parameter `the_id`, but `delete` in the restapi does not accept this.

https://github.com/markciecior/ConnectPyse/blob/1cd82ab94a9973cdf69c0d872bf45e3d0244d34a/restapi.py#L184

Additionally, the `delete` method should accept a return of 204 (No Content) for a successful deletion
https://github.com/markciecior/ConnectPyse/blob/1cd82ab94a9973cdf69c0d872bf45e3d0244d34a/restapi.py#L192
