### PR TITLE
Changed object to dict conversion to included 'false' Boolean values

### DIFF
--- a/cw_controller.py
+++ b/cw_controller.py
@@ -34,7 +34,7 @@ class CWController(Client):
     def _create(self, a_object):
         # Ideally take the_item and submit that as the user_data
         try:
-            clean_dict = {k: v for k, v in a_object.__dict__.items() if v}
+            clean_dict = {k: v for k, v in a_object.__dict__.items() if v is not None}
         except Exception as e:
             print(repr(e))
             return False


### PR DESCRIPTION
Hi, 

The issue I encountered was when creating a new time entry via POST to '/time/entries' ([REST API Time Documentation: Create Time Entry.](https://marketplace.connectwise.com/docs/redoc/manage/time.html#tag/TimeEntries/paths/~1time~1entries/post)) The API default value for '`addToDetailDescriptionFlag`' is '`True`.' 

The following code can be used to reproduce the error: 
```python
time_entry_json = {"chargeToId": self.id,
                               "chargeToType": charge_to_type,
                               "timeStart": time_start.strftime("%Y-%m-%dT%H:%M:%SZ"),
                               "timeEnd": time_end.strftime("%Y-%m-%dT%H:%M:%SZ"),
                               "member": {'id': resource.id},
                               "notes": note_text,
                               "addToDetailDescriptionFlag": False,
                               "addToInternalAnalysisFlag": True,
                               "billableOption": billable_option
                               }
time_entry_tmp = time_entry.TimeEntry(time_entry_json)
my_api = time_entries_api.TimeEntriesAPI(url=self.cw_model.API_URL, auth=self.cw_model.basic_auth)
myapi.create_time_entry(time_entry_tmp)
```

When converting the `TimeEntry` object to a dict in the method `_create`, will not include any object attribute that was purposely set to `False`. Thus, it will later not be included in the POST which results in the value "                               "`addToDetailDescriptionFlag": False`" not actually being POSTed to the API endpoint. 

Reach out if you got any questions! 

Regards, 
Philipp
