### PR TITLE
fix: always convert json payloads to ascii

### DIFF
--- a/connectpyse/config.py
+++ b/connectpyse/config.py
@@ -14,6 +14,7 @@ try:
       cw_api_settings = json.load(fin)
   
   API_URL = cw_api_settings['API_URL']
+  ENSURE_ASCII = cw_api_settings['ENSURE_ASCII'] if 'ENSURE_ASCII' in cw_api_settings else False
   _cid = cw_api_settings['COMPANYID']
   _pubk = cw_api_settings['PUBLICKEY']
   _privk = cw_api_settings['PRIVATEKEY']
@@ -31,4 +32,5 @@ try:
     basic_auth['clientId'] = _clientId
 except FileNotFoundError as e:
   API_URL = ''
+  ENSURE_ASCII = False
   basic_auth = {}

--- a/connectpyse/cw_controller.py
+++ b/connectpyse/cw_controller.py
@@ -1,10 +1,10 @@
 # Parent class for module controller classes
-from .config import API_URL, basic_auth
+from .config import API_URL, basic_auth, ENSURE_ASCII
 from .restapi import Client
 
 
 class CWController(Client):
-    def __init__(self, url=None, auth=None):
+    def __init__(self, url=None, auth=None, ensure_ascii=None):
         # self.module_url comes from child
         # self.module comes from child
         # self._class comes from child
@@ -16,6 +16,7 @@ class CWController(Client):
         self.pageSize = ''
         self.API_URL = url if url is not None else API_URL
         self.basic_auth = auth if auth is not None else basic_auth
+        self.ensure_ascii = ensure_ascii if ensure_ascii is not None else ENSURE_ASCII
         super().__init__('{}/{}'.format(self.API_URL, self.module_url))
 
     def _format_user_params(self):

--- a/connectpyse/restapi.py
+++ b/connectpyse/restapi.py
@@ -93,7 +93,7 @@ class Endpoint(object):
             url = self._url(self.endpoint)
 
         if user_data:
-            strjsondata = json.dumps(user_data, ensure_ascii=False)
+            strjsondata = json.dumps(user_data, ensure_ascii=True)
             resp = req.post(
                 url,
                 data=strjsondata,
@@ -121,7 +121,7 @@ class Endpoint(object):
 
     def put(self, the_id, user_data, user_params={}, user_headers={}):
 
-        strjsondata = json.dumps(user_data, ensure_ascii=False)
+        strjsondata = json.dumps(user_data, ensure_ascii=True)
 
         resp = req.put(
             self._url(self.endpoint, the_id),
@@ -141,7 +141,7 @@ class Endpoint(object):
 
     def patch(self, the_id, user_data, user_params={}, user_headers={}):
 
-        strjsondata = json.dumps(user_data, ensure_ascii=False)
+        strjsondata = json.dumps(user_data, ensure_ascii=True)
 
         resp = req.patch(
             self._url(self.endpoint, the_id),

--- a/connectpyse/restapi.py
+++ b/connectpyse/restapi.py
@@ -43,15 +43,17 @@ class Client(object):
         except AttributeError:
             return Endpoint(
                 self.root_path,
-                attr
+                attr,
+                ensure_ascii=self.ensure_ascii
             )
 
 
 class Endpoint(object):
 
-    def __init__(self, root_path, endpoint):
+    def __init__(self, root_path, endpoint, ensure_ascii):
         self.endpoint = endpoint
         self.root_path = root_path
+        self.ensure_ascii = ensure_ascii
 
     def _url(self, path, *args):
         url = "{}/{}/".format(self.root_path, path)
@@ -93,7 +95,7 @@ class Endpoint(object):
             url = self._url(self.endpoint)
 
         if user_data:
-            strjsondata = json.dumps(user_data, ensure_ascii=True)
+            strjsondata = json.dumps(user_data, ensure_ascii=self.ensure_ascii)
             resp = req.post(
                 url,
                 data=strjsondata,
@@ -121,7 +123,7 @@ class Endpoint(object):
 
     def put(self, the_id, user_data, user_params={}, user_headers={}):
 
-        strjsondata = json.dumps(user_data, ensure_ascii=True)
+        strjsondata = json.dumps(user_data, ensure_ascii=self.ensure_ascii)
 
         resp = req.put(
             self._url(self.endpoint, the_id),
@@ -141,7 +143,7 @@ class Endpoint(object):
 
     def patch(self, the_id, user_data, user_params={}, user_headers={}):
 
-        strjsondata = json.dumps(user_data, ensure_ascii=True)
+        strjsondata = json.dumps(user_data, ensure_ascii=self.ensure_ascii)
 
         resp = req.patch(
             self._url(self.endpoint, the_id),


### PR DESCRIPTION
The POST, PUT and PATCH methods do not convert all payloads to ASCII as `ensure_ascii=False` is set on the calls to `json.dumps()`.

Currently, if you to send a POST or PATCH request that contains UTF-8 characters to the ConnectWise API, you receive an error.

e.g.

```python
>>> data = [{"op": "replace", "path": "firstName", "value": "Liám"}]
>>> payload = json.dumps(
...   data, ensure_ascii=False # current connectpyse behaviour
... )
>>> response = requests.request("PATCH", url, headers=headers, data=payload)
>>> response.raise_for_status()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".venv/lib/python3.11/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://redacted/v4_6_release/apis/3.0/company/contacts/5651
>>> response.json()
{'code': 'ConnectWiseApi', 'message': 'The JSON input is not in the expected array format for a JSON Patch document. A JSON Patch document should be a JSON array of patch operations. Please revise your JSON structure and try again.'}
```

If you set `ensure_ascii=True`, which is the default of `json.dumps()`, the request is accepted:

```python
>>> payload = json.dumps(
...   data, ensure_ascii=True # default json behaviour
... )
>>>
>>> response = requests.request("PATCH", url, headers=headers, data=payload)
>>> response.raise_for_status()
>>> response.status_code
200
```

This PR replaces all usage of `ensure_ascii=False` with `ensure_ascii=True`. 

I'm happy to flesh this out a bit more if you want this setting to be controlled by the user.

Note that I am testing against an on-prem instance of ConnectWise (v2024.6.100619).