### PR TITLE
Fields Query Parameter & Info API Endpoint

### DIFF
--- a/connectpyse/cw_controller.py
+++ b/connectpyse/cw_controller.py
@@ -14,6 +14,7 @@ class CWController(Client):
         self.customfieldconditions = ''
         self.page = ''
         self.pageSize = ''
+        self.fields = ''
         self.API_URL = url if url is not None else API_URL
         self.basic_auth = auth if auth is not None else basic_auth
         self.ensure_ascii = ensure_ascii if ensure_ascii is not None else ENSURE_ASCII
@@ -21,7 +22,7 @@ class CWController(Client):
 
     def _format_user_params(self):
         user_params = {}
-        for param in ['conditions', 'orderBy', 'childconditions', 'customfieldconditions', 'page', 'pageSize', 'recordId', 'recordType']:
+        for param in ['conditions', 'orderBy', 'childconditions', 'customfieldconditions', 'page', 'pageSize', 'recordId', 'recordType', 'fields']:
             if getattr(self, param) != '':
               user_params[param] = getattr(self, param)
         return user_params

--- a/connectpyse/system/info.py
+++ b/connectpyse/system/info.py
@@ -4,9 +4,14 @@ from ..cw_model import CWModel
 class Info(CWModel):
 
     def __init__(self, json_dict=None):
-        self.version = None  # (String)
+        self.cloudRegion = None # (String)
         self.isCloud = None  # (Boolean)
+        self.licenseBits = None # (list(dict))
+        self.maxWorkFlowRecordsAllowed = None # Int
         self.serverTimeZone = None  # (String)
+        self.version = None  # (String)
+        
+
 
         # initialize object with json dict
         super().__init__(json_dict)

--- a/connectpyse/system/info_api.py
+++ b/connectpyse/system/info_api.py
@@ -4,12 +4,17 @@ from connectpyse.system import info
 
 class InfoAPI(CWController):
     def __init__(self, **kwargs):
+        """
+            *Fields attribute is not supported*
+        """
         self.module_url = 'system'
         self.module = 'info'
         self._class = info.Info
         super().__init__(**kwargs)  # instance gets passed to parent object
+        
 
     def get_info(self):
-        an_instance = self._class(getattr(self, self.module).get(user_headers=self.basic_auth))
+        an_instance = self._class(getattr(self, self.module).get(user_headers=self.basic_auth, 
+                                                                 user_params=self._format_user_params()))
         return an_instance
         

--- a/connectpyse/system/info_api.py
+++ b/connectpyse/system/info_api.py
@@ -1,0 +1,15 @@
+from ..cw_controller import CWController
+# Class for /system/info
+from connectpyse.system import info
+
+class InfoAPI(CWController):
+    def __init__(self, **kwargs):
+        self.module_url = 'system'
+        self.module = 'info'
+        self._class = info.Info
+        super().__init__(**kwargs)  # instance gets passed to parent object
+
+    def get_info(self):
+        an_instance = self._class(getattr(self, self.module).get(user_headers=self.basic_auth))
+        return an_instance
+        

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
     long_description = f.read()
 
 setup(name='connectpyse',
-      version='0.7.1',
+      version='0.7.2',
       description='A ConnectWise API tool for the rest of us.',
       long_description=long_description,
       long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as f:
     long_description = f.read()
 
 setup(name='connectpyse',
-      version='0.7.2',
+      version='0.7.3',
       description='A ConnectWise API tool for the rest of us.',
       long_description=long_description,
       long_description_content_type="text/markdown",


### PR DESCRIPTION
Info_API endpoint support. It is the only endpoint in the OpenAPI spec that I found that returns a single object without an ID. 

Added fields support and tested it's use on BoardInfo Endpoint. It does not work with Info_api. Filed case with support and they will probably remove it's support from the spec OR support it per the spec.

Also updated version for each change separably. 